### PR TITLE
Fix two ways body redaction silently did not run

### DIFF
--- a/packages/common/src/apitoolkit.test.ts
+++ b/packages/common/src/apitoolkit.test.ts
@@ -169,9 +169,50 @@ describe('setAttributes', () => {
     expect(decodedRequest.username).toBe('test');
     expect(decodedRequest.password).toBe('[CLIENT_REDACTED]');
 
-    // There's a bug in the implementation - it uses redactRequestBody for response body too
+    // redactResponseBody has to apply to the response. It was previously passed
+    // redactRequestBody, so every path configured here was silently ignored and response
+    // bodies — the ones carrying tokens, session ids and emails — went out unredacted.
     const decodedResponse = JSON.parse(Buffer.from(attrs['http.response.body'], 'base64').toString());
-    expect(decodedResponse.token).toBe('jwt-token'); // Not redacted due to bug
+    expect(decodedResponse.token).toBe('[CLIENT_REDACTED]');
+  });
+
+  // The two lists are independent: a path configured for one must not redact the other, or
+  // "redact this from responses" would quietly start blanking request fields too.
+  it('keeps the request and response redaction lists separate', () => {
+    const config: Config = {
+      redactHeaders: [],
+      redactRequestBody: ['$.password'],
+      redactResponseBody: ['$.token'],
+    };
+
+    setAttributes(
+      mockSpan as any,
+      'example.com',
+      200,
+      {},
+      {},
+      {},
+      {},
+      'POST',
+      '/auth',
+      'msg-102',
+      '/auth',
+      JSON.stringify({ username: 'test', password: 'secret', token: 'req-token' }),
+      JSON.stringify({ token: 'jwt-token', password: 'resp-password' }),
+      [],
+      config,
+      'JsExpress',
+      undefined
+    );
+
+    const attrs = mockSpan.setAttributes.mock.calls[0][0];
+    const req = JSON.parse(Buffer.from(attrs['http.request.body'], 'base64').toString());
+    const res = JSON.parse(Buffer.from(attrs['http.response.body'], 'base64').toString());
+
+    expect(req.password).toBe('[CLIENT_REDACTED]');
+    expect(req.token).toBe('req-token');
+    expect(res.token).toBe('[CLIENT_REDACTED]');
+    expect(res.password).toBe('resp-password');
   });
 });
 

--- a/packages/common/src/apitoolkit.test.ts
+++ b/packages/common/src/apitoolkit.test.ts
@@ -1,5 +1,5 @@
 import { SpanStatusCode } from '@opentelemetry/api';
-import { setAttributes, ReportError, ATError, asyncLocalStorage, Config } from './apitoolkit';
+import { setAttributes, ReportError, ATError, asyncLocalStorage, Config, redactFields } from './apitoolkit';
 
 describe('setAttributes', () => {
   const mockSpan = {
@@ -174,6 +174,21 @@ describe('setAttributes', () => {
     // bodies — the ones carrying tokens, session ids and emails — went out unredacted.
     const decodedResponse = JSON.parse(Buffer.from(attrs['http.response.body'], 'base64').toString());
     expect(decodedResponse.token).toBe('[CLIENT_REDACTED]');
+  });
+
+  // Frameworks do not agree on what a body is: Next's Pages Router hands the wrapper an
+  // already-parsed object. That used to fall through JSON.parse -> throw -> return-as-is,
+  // so redaction silently did not happen and the raw payload was exported. Redaction that
+  // no-ops on the wrong input type is worse than none, because it is invisible.
+  it('redacts a body that arrives already parsed, and does not mutate it', () => {
+    const body = { userId: 'u1', creditCard: { creditCardNumber: '4432-8015-6152-0454' } };
+
+    const out = redactFields(body, ['$..creditCard']);
+
+    expect(JSON.parse(out).creditCard).toBe('[CLIENT_REDACTED]');
+    // jsonpath.apply mutates in place; the caller's req.body must survive untouched, or the
+    // application reads blanked fields it is about to use.
+    expect(body.creditCard.creditCardNumber).toBe('4432-8015-6152-0454');
   });
 
   // The two lists are independent: a path configured for one must not redact the other, or

--- a/packages/common/src/apitoolkit.ts
+++ b/packages/common/src/apitoolkit.ts
@@ -54,7 +54,7 @@ export function setAttributes(
         redactFields(reqBody, config.redactRequestBody || [])
       ).toString("base64"),
       "http.response.body": Buffer.from(
-        redactFields(respBody, config.redactRequestBody || [])
+        redactFields(respBody, config.redactResponseBody || [])
       ).toString("base64"),
       "apitoolkit.errors": JSON.stringify(errors),
       "apitoolkit.service_version": config.serviceVersion || "",

--- a/packages/common/src/apitoolkit.ts
+++ b/packages/common/src/apitoolkit.ts
@@ -112,9 +112,27 @@ export function redactHeaders(
   return redactedHeaders;
 }
 
-export function redactFields(body: string, fieldsToRedact: string[]): string {
+/**
+ * Redact the given JSONPaths out of a JSON body.
+ *
+ * `body` is typed as a string, but callers hand it whatever their framework gives them and
+ * some frameworks give an already-parsed object — Next's Pages Router populates
+ * `req.body` as an object, for instance. That used to fall straight through: `JSON.parse`
+ * of an object stringifies it to `"[object Object]"`, throws, and the catch returned the
+ * body untouched — so redaction silently did not happen and the raw payload was exported.
+ * A redactor that no-ops on the wrong input type is worse than one that fails loudly.
+ *
+ * Accepting objects here fixes it for every SDK at once rather than at each call site.
+ */
+export function redactFields(body: unknown, fieldsToRedact: string[]): string {
+  const asString = () => (typeof body === "string" ? body : JSON.stringify(body) ?? "");
   try {
-    const bodyOB = JSON.parse(body);
+    // Parse a string; deep-copy an object. jsonpath.apply mutates in place, and the object
+    // handed in is the framework's own req.body — redacting it directly would blank fields
+    // the application itself is about to read.
+    const bodyOB =
+      typeof body === "string" ? JSON.parse(body) : JSON.parse(JSON.stringify(body));
+    if (bodyOB === null || typeof bodyOB !== "object") return asString();
     fieldsToRedact.forEach((path) => {
       jsonpath.apply(bodyOB, path, function () {
         return "[CLIENT_REDACTED]";
@@ -122,7 +140,7 @@ export function redactFields(body: string, fieldsToRedact: string[]): string {
     });
     return JSON.stringify(bodyOB);
   } catch (error) {
-    return body;
+    return asString();
   }
 }
 


### PR DESCRIPTION
Two independent bugs, both of which made configured redaction quietly not happen. Neither fails loudly, which is why both survived.

## 1. `redactResponseBody` was ignored

`setAttributes` passed `config.redactRequestBody` when redacting the **response** body:

```diff
       "http.response.body": Buffer.from(
-        redactFields(respBody, config.redactRequestBody || [])
+        redactFields(respBody, config.redactResponseBody || [])
       ).toString("base64"),
```

The option is documented and accepted, so callers reasonably assume it works — response bodies carrying tokens, session ids and emails went out unredacted.

The existing test encoded the bug as expected behaviour, so it could never fail:

```ts
// There's a bug in the implementation - it uses redactRequestBody for response body too
expect(decodedResponse.token).toBe('jwt-token'); // Not redacted due to bug
```

## 2. Bodies that arrive already parsed were never redacted

`redactFields` is typed `(body: string, …)`, but callers hand it whatever their framework gives them — and **Next's Pages Router populates `req.body` as an object**. `JSON.parse` of an object stringifies to `"[object Object]"`, throws, and the catch returned the body untouched.

Verified against the built package:

```
object in  ->  {"userId":"u1","creditCard":{"creditCardNumber":"4432-8015-6152-0454"}}   ← leaked
string in  ->  {"userId":"u1","creditCard":"[CLIENT_REDACTED]"}
```

Found on the OpenTelemetry demo: `withMonoscopePagesRouter` passes `request.body` straight through, so **no request body was ever redacted on a Next Pages Router app**.

Accepting objects in `redactFields` fixes it for every SDK at once rather than at each call site. The object is deep-copied first — `jsonpath.apply` mutates in place, and the object handed in is the framework's own `req.body`, so redacting it directly would blank fields the application is about to read.

## Tests

Three added/corrected, all failing against the old implementation:
- the response-body assertion now asserts redaction instead of enshrining the leak
- the two redaction lists are pinned as independent
- a parsed-object body is redacted **and** the caller's object is left untouched