### PR TITLE
Declare axios, which both packages import but neither required

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,6 +20,7 @@
     "directory": "packages/common"
   },
   "dependencies": {
+    "axios": "^1.12.2",
     "jsonpath": "^1.1.1",
     "uuid": "^11.0.3"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@monoscopetech/common": "workspace:*",
+    "axios": "^1.12.2",
     "uuid": "^11.0.3"
   },
   "keywords": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
 
   packages/common:
     dependencies:
+      axios:
+        specifier: ^1.12.2
+        version: 1.12.2
       jsonpath:
         specifier: ^1.1.1
         version: 1.1.1
@@ -133,9 +136,6 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.18.4
-      axios:
-        specifier: ^1.7.9
-        version: 1.12.2
       del-cli:
         specifier: ^5.1.0
         version: 5.1.0
@@ -237,6 +237,9 @@ importers:
       '@monoscopetech/common':
         specifier: workspace:*
         version: link:../common
+      axios:
+        specifier: ^1.12.2
+        version: 1.12.2
       uuid:
         specifier: ^11.0.3
         version: 11.1.0
@@ -253,9 +256,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.9
         version: 19.1.9(@types/react@19.1.13)
-      axios:
-        specifier: ^1.7.9
-        version: 1.12.2
       del-cli:
         specifier: ^5.1.0
         version: 5.1.0
@@ -1232,7 +1232,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: false
 
   /@jest/diff-sequences@30.0.1:
     resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
@@ -2603,7 +2602,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -2632,7 +2630,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /babel-code-frame@6.26.0:
     resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==}
@@ -3213,7 +3210,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -3384,7 +3380,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: false
 
   /create-jest@29.7.0(@types/node@22.18.4):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -3632,7 +3627,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4518,7 +4512,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -4536,7 +4529,6 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-    dev: true
 
   /formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
@@ -5612,7 +5604,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: false
 
   /jest-cli@29.7.0(@types/node@22.18.4):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
@@ -5748,7 +5739,6 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    dev: false
 
   /jest-config@29.7.0(@types/node@22.18.4):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
@@ -5869,7 +5859,6 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    dev: false
 
   /jest-diff@25.5.0:
     resolution: {integrity: sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==}
@@ -6259,7 +6248,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: false
 
   /jest@29.7.0(@types/node@22.18.4):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
@@ -6744,7 +6732,6 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -6756,7 +6743,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
   /mime-types@3.0.1:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
@@ -7546,7 +7532,6 @@ packages:
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: true
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -8796,7 +8781,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@22.18.4)
+      jest: 29.7.0(@types/node@20.19.15)(ts-node@10.9.2)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
`packages/common` re-exports `./axios` from its entry point, so **importing the package at all** pulls in `axios` — but `axios` was never declared as a dependency. Anywhere it is not already present transitively, importing the SDK throws.

### Reproduced against what is on npm

```console
$ npm init -y && npm install @monoscopetech/common@1.1.1
$ node -e "require('@monoscopetech/common')"
Error: Cannot find module 'axios'
Require stack:
- node_modules/@monoscopetech/common/dist/axios.js
- node_modules/@monoscopetech/common/dist/index.js
```

### Why it is easy to miss

It only shows up in a production install. The OpenTelemetry demo's frontend built and typechecked fine locally — the dev tree had axios transitively — and then **500'd on every request** inside the image, where `npm ci --omit=dev` does not. The public demo served errors until it was rolled back.

`packages/nextjs` imports axios in `src/axios.ts` and had the same gap, so both are declared here.

Pinned `^1.12.2`, matching what the workspace already resolves.