### PR TITLE
Add gRPC payload capture (observeGrpc)

### DIFF
--- a/packages/adonis/package.json
+++ b/packages/adonis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@monoscopetech/adonis",
   "description": "",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "index.js",
   "type": "module",
   "files": [
@@ -55,7 +55,7 @@
     "@japa/assert": "^2.1.0",
     "@japa/runner": "^3.1.1",
     "@japa/spec-reporter": "^1.3.3",
-    "@monoscopetech/common": "workspace:*",
+    "@monoscopetech/common": "1.3.0",
     "@opentelemetry/api": "^1.9.0",
     "@poppinss/dev-utils": "^2.0.3",
     "@poppinss/utils": "^6.7.3",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monoscopetech/common",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/common/src/apitoolkit.ts
+++ b/packages/common/src/apitoolkit.ts
@@ -34,7 +34,8 @@ export function setAttributes(
     | `JsFastify`
     | `JsAdonis`
     | "JsAxiosOutgoing"
-    | "JsNext",
+    | "JsNext"
+    | "JsGrpc",
   parentId: string | undefined,
   customAttributes?: Record<string, any>
 ) {

--- a/packages/common/src/grpc.test.ts
+++ b/packages/common/src/grpc.test.ts
@@ -1,0 +1,116 @@
+import { observeGrpc } from "./grpc";
+
+// The span the interceptor writes to, captured so each test can assert on what was recorded
+// rather than on what was logged.
+let attrs: Record<string, any> = {};
+let ended = 0;
+let status: any = null;
+
+jest.mock("@opentelemetry/api", () => ({
+  trace: {
+    getTracer: () => ({
+      startActiveSpan: (_name: string, fn: (span: any) => any) =>
+        fn({
+          setAttributes: (a: Record<string, any>) => Object.assign(attrs, a),
+          setAttribute: (k: string, v: any) => (attrs[k] = v),
+          setStatus: (s: any) => (status = s),
+          recordException: () => {},
+          end: () => ended++,
+        }),
+    }),
+  },
+  SpanStatusCode: { ERROR: 2 },
+}));
+
+const decode = (key: string) =>
+  JSON.parse(Buffer.from(attrs[key], "base64").toString());
+
+beforeEach(() => {
+  attrs = {};
+  ended = 0;
+  status = null;
+});
+
+const METHOD = "/oteldemo.PaymentService/Charge";
+
+test("captures request and response bodies as base64 on a monoscope.http span", done => {
+  const handler = (_call: any, cb: any) => cb(null, { transactionId: "txn-1" });
+  observeGrpc({ method: METHOD }, handler)({ request: { a: 1 } }, (err, res) => {
+    expect(err).toBeNull();
+    expect(res).toEqual({ transactionId: "txn-1" });
+    expect(decode("http.request.body")).toEqual({ a: 1 });
+    expect(decode("http.response.body")).toEqual({ transactionId: "txn-1" });
+    expect(attrs["http.route"]).toBe(METHOD);
+    expect(attrs["apitoolkit.sdk_type"]).toBe("JsGrpc");
+    expect(attrs["rpc.system"]).toBe("grpc");
+    expect(attrs["rpc.grpc.status_code"]).toBe(0);
+    expect(ended).toBe(1);
+    done();
+  });
+});
+
+// The reason this SDK version exists rather than the hand-rolled one: redaction comes from the
+// user's own JSONPath config. A gRPC request arrives already decoded, which is the exact path
+// where redaction previously did JSON.parse on an object, threw, and returned it untouched.
+test("redacts a decoded request message using the caller's JSONPath config", done => {
+  const config = {
+    method: METHOD,
+    redactRequestBody: ["$.creditCard.creditCardNumber", "$.creditCard.creditCardCvv"],
+  };
+  const request = {
+    amount: { units: 42 },
+    creditCard: { creditCardNumber: "4432-8015-6152-0454", creditCardCvv: 672 },
+  };
+  observeGrpc(config, (_c: any, cb: any) => cb(null, {}))({ request }, () => {
+    const body = decode("http.request.body");
+    expect(body.creditCard.creditCardNumber).not.toBe("4432-8015-6152-0454");
+    expect(body.creditCard.creditCardCvv).not.toBe(672);
+    expect(body.amount.units).toBe(42); // non-sensitive fields survive
+    done();
+  });
+});
+
+test("collapses a protobuf Long so it is not captured as {low, high, unsigned}", done => {
+  const request = { amount: { units: { low: 42, high: 0, unsigned: false } } };
+  observeGrpc({ method: METHOD }, (_c: any, cb: any) => cb(null, {}))({ request }, () => {
+    expect(decode("http.request.body")).toEqual({ amount: { units: "42" } });
+    done();
+  });
+});
+
+test("captures the error path and passes the error through unchanged", done => {
+  const failure = Object.assign(new Error("card declined"), { code: 7 });
+  observeGrpc({ method: METHOD }, (_c: any, cb: any) => cb(failure))({ request: {} }, err => {
+    expect(err).toBe(failure); // the caller's own error object, not a wrapper
+    expect(decode("http.response.body")).toEqual({ error: "card declined" });
+    expect(attrs["http.response.status_code"]).toBe(500);
+    expect(attrs["rpc.grpc.status_code"]).toBe(7); // PERMISSION_DENIED, not flattened to 500
+    expect(status.code).toBe(2);
+    done();
+  });
+});
+
+test("a handler that throws synchronously still ends the span and reaches the callback", done => {
+  const boom = new Error("boom");
+  observeGrpc({ method: METHOD }, () => {
+    throw boom;
+  })({ request: {} }, err => {
+    expect(err).toBe(boom);
+    expect(ended).toBe(1); // without this the span leaks and the caller hangs
+    done();
+  });
+});
+
+test("an unserialisable request degrades to no body rather than failing the RPC", done => {
+  const cyclic: any = { a: 1 };
+  cyclic.self = cyclic;
+  observeGrpc({ method: METHOD }, (_c: any, cb: any) => cb(null, { ok: true }))(
+    { request: cyclic },
+    (err, res) => {
+      expect(err).toBeNull();
+      expect(res).toEqual({ ok: true });
+      expect(Buffer.from(attrs["http.request.body"], "base64").toString()).toBe("");
+      done();
+    }
+  );
+});

--- a/packages/common/src/grpc.ts
+++ b/packages/common/src/grpc.ts
@@ -1,0 +1,139 @@
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import { setAttributes, Config, ATError } from "./apitoolkit";
+
+/**
+ * gRPC payload capture.
+ *
+ * Every other integration in this SDK is an HTTP middleware, which leaves a gRPC service with
+ * no request or response payloads at all. This closes that gap without depending on a gRPC
+ * package: a unary handler is just `(call, callback)`, so wrapping one needs no import beyond
+ * the OpenTelemetry API this package already uses. It therefore works with `@grpc/grpc-js`,
+ * with generated service stubs, and with anything else presenting the same shape.
+ */
+
+/**
+ * protobuf-js decodes a 64-bit field into a Long — `{low, high, unsigned}` — which
+ * JSON.stringify renders verbatim, so an amount would be captured as
+ * `{"low":42,"high":0,"unsigned":false}` rather than `"42"`. That reads as broken capture, and
+ * it also defeats a JSONPath redaction rule written against the value the user expects.
+ */
+const isLong = (v: any): boolean =>
+  v !== null &&
+  typeof v === "object" &&
+  typeof v.low === "number" &&
+  typeof v.high === "number";
+
+const normalize = (value: any): any => {
+  if (isLong(value)) return String(value.high * 2 ** 32 + (value.low >>> 0));
+  if (Buffer.isBuffer(value)) return value.toString("base64");
+  if (Array.isArray(value)) return value.map(normalize);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, normalize(v)])
+    );
+  }
+  return value;
+};
+
+// Best-effort by design: capture must never be the reason an RPC fails, so a message that
+// cannot be represented (a cycle, an exotic field) degrades to no body rather than to an
+// exception thrown on the request path.
+const toBodyString = (value: any): string => {
+  try {
+    return JSON.stringify(normalize(value)) ?? "";
+  } catch {
+    return "";
+  }
+};
+
+// A gRPC error carries a numeric `code`; anything else is an unexpected throw. `2` is UNKNOWN,
+// which is what gRPC itself reports for a handler that failed without saying how.
+const grpcStatusOf = (err: any): number =>
+  typeof err?.code === "number" ? err.code : 2;
+
+export interface GrpcConfig extends Config {
+  /**
+   * The RPC path, e.g. `/oteldemo.PaymentService/Charge`. Recorded as the route, which is what
+   * groups calls together in the UI, so it should identify the method rather than the call.
+   */
+  method: string;
+}
+
+type GrpcCallback = (err: any, response?: any) => void;
+type GrpcHandler = (call: { request: any }, callback: GrpcCallback) => void;
+
+/**
+ * Wrap a unary gRPC handler so Monoscope captures its request and response payloads.
+ *
+ * ```ts
+ * server.addService(svc, {
+ *   charge: observeGrpc({ method: "/oteldemo.PaymentService/Charge",
+ *                         redactRequestBody: ["$.creditCard.creditCardNumber"] },
+ *                       chargeHandler),
+ * });
+ * ```
+ *
+ * The span is a child of whatever gRPC auto-instrumentation already produced rather than a
+ * replacement for it, so the trace keeps its usual shape and this only adds payload detail.
+ *
+ * Streaming RPCs are **not** covered: there is no single request or response message to
+ * capture. Wrapping one would silently record nothing, so it is better to know that this
+ * applies to unary calls only.
+ */
+export function observeGrpc(config: GrpcConfig, handler: GrpcHandler): GrpcHandler {
+  return (call, callback) =>
+    trace.getTracer("monoscope").startActiveSpan("monoscope.http", (span) => {
+      // The RPC's own outcome must be unaffected by capture, so every path below hands the
+      // handler's (err, response) back untouched.
+      const finish = (err: any, response?: any) => {
+        try {
+          setAttributes(
+            span,
+            "",
+            err ? 500 : 200,
+            {},
+            {},
+            {},
+            {},
+            "POST",
+            config.method,
+            "",
+            config.method,
+            toBodyString(call.request),
+            toBodyString(err ? { error: err.message } : response),
+            [] as ATError[],
+            config,
+            "JsGrpc",
+            undefined,
+            {
+              // Emitted alongside the HTTP-shaped fields above, not instead of them. The lift
+              // that puts bodies in front of the user keys off the HTTP shape, but a gRPC
+              // status says more than "ok or not" — NOT_FOUND and RESOURCE_EXHAUSTED both
+              // flatten to 500 — so the real one is recorded too.
+              "rpc.system": "grpc",
+              "rpc.method": config.method,
+              "rpc.grpc.status_code": err ? grpcStatusOf(err) : 0,
+            }
+          );
+          if (err) {
+            span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          }
+        } catch {
+          // setAttributes ends the span itself; if it threw before doing so the span would
+          // leak, and in a long-running server that accumulates per request.
+          try {
+            span.end();
+          } catch {}
+        }
+        callback(err, response);
+      };
+
+      try {
+        handler(call, finish);
+      } catch (err) {
+        // A handler that throws synchronously never reaches its callback, so without this the
+        // span would never end and the caller would hang.
+        finish(err);
+      }
+    });
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,3 +12,4 @@ export {
   MonoscopeTenant,
 } from "./apitoolkit";
 export { observeAxios, observeAxiosGlobal, AxiosConfig } from "./axios";
+export { observeGrpc, GrpcConfig } from "./grpc";

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monoscopetech/express",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -20,7 +20,7 @@
     "directory": "packages/express"
   },
   "dependencies": {
-    "@monoscopetech/common": "workspace:*",
+    "@monoscopetech/common": "1.3.0",
     "uuid": "^11.0.3"
   },
   "devDependencies": {

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monoscopetech/fastify",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -20,7 +20,7 @@
     "directory": "packages/fastify"
   },
   "dependencies": {
-    "@monoscopetech/common": "workspace:*",
+    "@monoscopetech/common": "1.3.0",
     "uuid": "^11.0.3"
   },
   "keywords": [],

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monoscopetech/next",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -20,7 +20,7 @@
     "directory": "packages/nextjs"
   },
   "dependencies": {
-    "@monoscopetech/common": "workspace:*",
+    "@monoscopetech/common": "1.3.0",
     "axios": "^1.12.2",
     "uuid": "^11.0.3"
   },


### PR DESCRIPTION
Every integration in this SDK is an HTTP middleware, so a gRPC service gets no request or response payloads at all. `observeGrpc` closes that for unary calls.

**No new dependency.** A unary handler is just `(call, callback)`, so wrapping one needs nothing beyond the OpenTelemetry API this package already uses — it works with `@grpc/grpc-js`, generated stubs, or anything of that shape.

```ts
server.addService(svc, {
  charge: observeGrpc(
    { method: "/oteldemo.PaymentService/Charge",
      redactRequestBody: ["$.creditCard.creditCardNumber"] },
    chargeHandler,
  ),
})
```

### Why it routes through `setAttributes`

Redaction comes from the caller's own JSONPath config rather than a hardcoded key list. That path is also where redaction has silently failed before: a gRPC message arrives **already decoded**, and `redactFields` used to `JSON.parse` an object, throw, and return it **unredacted**. There is a test pinning that a decoded credit card is redacted.

### Two things the naive version gets wrong (both tested)

- protobuf decodes int64 as a `Long`, so `JSON.stringify` renders `{low, high, unsigned}` instead of the number — defeating readability *and* any JSONPath rule written against the expected value.
- a handler that throws synchronously never reaches its callback, leaking the span and hanging the caller.

### Attributes

`rpc.system` / `rpc.method` / `rpc.grpc.status_code` are emitted **alongside** the HTTP-shaped fields, not instead of them. The server-side lift that surfaces bodies keys off the HTTP shape, but a gRPC status says more than ok-or-not (`NOT_FOUND` and `RESOURCE_EXHAUSTED` both flatten to 500), so the real one is recorded and ready for native rendering without an SDK re-release.

### Scope

Unary only. Streaming has no single message to capture, and wrapping it would silently record nothing — so it throws no surprise, it is documented as unsupported.

Tests: 6 new, full suite green. Version bumped to 1.3.0 across all five packages.

Cross-language plan for the rest of the SDKs: `docs/grpc-sdk-support.md` in the monoscope repo.